### PR TITLE
Support for custom YAML tags, allowing filenames to be specified at runtime

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 import argparse
 import os
 import yaml
-
+import tag_handlers
 
 class Pipeline():
     def __init__(self, name, host=None, steps=[], debug=False, pull_images=True):
@@ -255,6 +255,9 @@ class Step():
 
 
 def main(yaml_file):
+    var_map = defaultdict(lambda: None)
+    # TODO: Populate vars
+    tag_handlers.configure(var_map)
     p = Pipeline.from_yaml(yaml_file)
     p.run()
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -254,15 +254,24 @@ class Step():
         return environment
 
 
-def main(yaml_file):
-    var_map = defaultdict(lambda: None)
-    # TODO: Populate vars
+def main(yaml_file, var_map):
     tag_handlers.configure(var_map)
     p = Pipeline.from_yaml(yaml_file)
     p.run()
 
+
+def extract_var_map(leftovers):
+    d = defaultdict(lambda: None)
+    for leftover in leftovers:
+        k, v = leftover.split('=')
+        d[k] = v
+    return d
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('yaml_file', type=argparse.FileType('r'))
-    args = parser.parse_args()
-    main(args.yaml_file.name)
+    parser.add_argument_group()
+    args, leftovers = parser.parse_known_args()
+    var_map = extract_var_map(leftovers)
+    main(args.yaml_file.name, var_map)

--- a/tag_handlers.py
+++ b/tag_handlers.py
@@ -1,0 +1,51 @@
+__author__ = 'dcl9'
+import yaml
+from yaml.loader import ConstructorError
+import os.path
+
+
+def configure(var_map):
+    def join(loader, node):
+        """
+        YAML Tag handler to join components to a string
+        :param loader: YAML Loader
+        :param node: Node, can be sequence or space-separated scalars
+        :return: The components of node, will be joined together
+        """
+        try:
+            seq = loader.construct_sequence(node)
+            return ''.join([str(i) for i in seq])
+        except ConstructorError as e:
+            s = loader.construct_scalar(node)
+            return ''.join(s.split())
+
+
+    def interpret_var(loader, node):
+        """
+        YAML Tag handler to replace variables
+        :param loader: YAML Loader
+        :param node: Node, must be scalar
+        :return: The value from the 'vars' dict above matching the key represented by node
+        """
+        key = loader.construct_scalar(node)
+        return var_map[key]
+
+
+    def change_ext(loader, node):
+        """
+        YAML Tag handler to change extension of a file
+        :param loader: YAML Loader
+        :param node: Node, can be sequence or space-separated scalars. filename and new extension
+        :return: A file path, with the extension replaced
+        """
+        try:
+            seq = loader.construct_sequence(node)
+        except ConstructorError as e:
+            seq = loader.construct_scalar(node).split()
+        seq[0] = os.path.splitext(seq[0])[0]
+        return '.'.join(seq)
+
+    # Register tag handlers
+    yaml.add_constructor('!join', join)
+    yaml.add_constructor('!var', interpret_var)
+    yaml.add_constructor('!change_ext', change_ext)

--- a/tag_handlers.py
+++ b/tag_handlers.py
@@ -45,7 +45,22 @@ def configure(var_map):
         seq[0] = os.path.splitext(seq[0])[0]
         return '.'.join(seq)
 
+    def base(loader, node):
+        """
+        YAML Tag handler to get base name of a file
+        :param loader: YAML Loader
+        :param node: Node, can be sequence or scalar. File name in full path
+        :return: The file name from a path
+        """
+        try:
+            seq = loader.construct_sequence(node)
+        except ConstructorError as e:
+            seq = loader.construct_scalar(node).split()
+        path = seq[0]
+        return os.path.basename(path)
+
     # Register tag handlers
     yaml.add_constructor('!join', join)
     yaml.add_constructor('!var', interpret_var)
     yaml.add_constructor('!change_ext', change_ext)
+    yaml.add_constructor('!base', base)


### PR DESCRIPTION
Previously, filenames were hard-coded in the YAML file, requiring the YAML file to be edited in order to run a pipeline on a different data set.

This change set implements application-specific [tags](http://yaml.org/spec/1.2/spec.html#id2761292) to the YAML parsing, allowing for variable substitution and simple functions (join, manipulating file paths/extensions)

For example

**Command Line**

``` bash
pipeline.py my_pipeline.yaml SOURCE=/data/raw/file.csv OUTDIR=/data/results/
```

**YAML**

``` yaml
...
step:
  CONT_INPUT_DATA_FILE: !var SOURCE
  CONT_OUTPUT_RESULTS: !join [!var OUTDIR, results.csv]
```

**Runtime**

``` bash
CONT_INPUT_DATA_FILE=/data/raw/file.csv
CONT_OUTPUT_RESULTS=/data/results/results.csv
```

Tests and documentation forthcoming
