### PR TITLE
Configure API version automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ MAINTAINER Dan Leehr <dan.leehr@duke.edu>
 
 RUN apt-get update && apt-get install -y \
   python \
+  python-dev \
+  libffi-dev \
+  libssl-dev \
   python-pip
 
 COPY . /docker-pipeline

--- a/pipeline.py
+++ b/pipeline.py
@@ -76,7 +76,7 @@ class Pipeline():
         # Using boot2docker instructions for now
         # http://docker-py.readthedocs.org/en/latest/boot2docker/
         # Workaround for requests.exceptions.SSLError: hostname '192.168.59.103' doesn't match 'boot2docker'
-        client = Client(**kwargs_from_env(assert_hostname=False))
+        client = Client(version='auto', **kwargs_from_env(assert_hostname=False))
         return client
 
     def run(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,13 @@
 backports.ssl-match-hostname==3.4.0.2
+cffi==0.9.2
+cryptography==0.8.2
 docker-py==1.1.0
+enum34==1.0.4
+ndg-httpsclient==0.3.3
 nose==1.3.6
+pyasn1==0.1.7
+pycparser==2.10
+pyOpenSSL==0.15.1
 PyYAML==3.11
 requests==2.6.0
 six==1.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 backports.ssl-match-hostname==3.4.0.2
-docker-py==1.0.0
+docker-py==1.1.0
+nose==1.3.6
 PyYAML==3.11
-requests==2.4.3
+requests==2.6.0
 six==1.9.0
-websocket-client==0.25.0
+websocket-client==0.29.0


### PR DESCRIPTION
Fixes #1

Using a new feature in docker-py 1.1.0, we need not specify the API version directly, and can instead say `'auto'`. This led to some other package upgrades (requests, and requests[security]). Unfortunately, these don't install on our HPC environment because libffi is missing.

Hurdles like missing dependencies are a large motivation here, so this should be held until #7 is merged, and docker-pipeline itself can run from Docker.
